### PR TITLE
fix: SQL issues & minor issues

### DIFF
--- a/contracts/TwoTablesNFT.sol
+++ b/contracts/TwoTablesNFT.sol
@@ -64,7 +64,7 @@ contract TwoTablesNFT is ERC721 {
 
         string memory query = string(
             abi.encodePacked(
-                "SELECT%20json_object%28%27id%27%2Cid%2C%27name%27%2Cname%2C%27description%27%2Cdescription%2C%27attributes%27%2Cjson_group_array%28json_object%28%27trait_type%27%2Ctrait_type%2C%27value%27%2Cvalue%29%29%29%20FROM%20",
+                "SELECT%20json_object%28%27id%27%2Cid%2C%27name%27%2Cname%2C%27description%27%2Cdescription%2C%27image%27%2Cimage%2C%27attributes%27%2Cjson_group_array%28json_object%28%27trait_type%27%2Ctrait_type%2C%27value%27%2Cvalue%29%29%29%20FROM%20",
                 mainTable,
                 "%20JOIN%20",
                 attributesTable,

--- a/scripts/deployTwoTables.js
+++ b/scripts/deployTwoTables.js
@@ -79,7 +79,7 @@ async function main() {
 
     for await (let attribute of attributes) {
       let { hash: attrWriteTx } = await tableland.write(attribute);
-      receipt = table.receipt(attrWriteTx);
+      receipt = tableland.receipt(attrWriteTx);
 
       if (receipt) {
         console.log(`${attributesName} table: ${attribute}`);

--- a/scripts/prepareSql.js
+++ b/scripts/prepareSql.js
@@ -28,7 +28,7 @@ async function prepareSqlForTwoTables(mainTable, attributesTable) {
         for await (let attribute of attributes){  //this loops through the attributes object we get when we destructure it from the metadata object
             const {trait_type, value} = attribute 
 
-            const attributesStatement = `INSERT INTO ${attributesTable} (main_id, trait_type, value) VALUES (${id}, '${trait_type}, '${value}');`
+            const attributesStatement = `INSERT INTO ${attributesTable} (main_id, trait_type, value) VALUES (${id}, '${trait_type}', '${value}');`
             //this prepares the insert statements for the attributes table, then wil append the statement to an array that holds the insert statements for all metadata objects
             attributesTableStatements.push(attributesStatement)
         }


### PR DESCRIPTION
- `prepareSql.js` had an insert that didn't wrap the text in a single quote
- `deployTwoTables.js` used the keyword `table` instead of `tableland`
- The smart contract had a slight bug where `image` was not part of the query; this was an issue from the tutorial itself